### PR TITLE
Simplify games template markup

### DIFF
--- a/views/games.erb
+++ b/views/games.erb
@@ -1,46 +1,28 @@
-<fieldset>
-  <ol>
-    <li>
-      <fieldset>
-      <div>
-        <h1>Nintendo 64 Series</h1>
-        </div>
-        </fieldset>
-        <fieldset>
-        <h2>Super Mario 64</h2>
-        <p>This article is about the original version. For the remake, see Super Mario 64 DS.</p>
-        <a href="https://en.wikipedia.org/wiki/Super_Mario_64">Super Mario 64 From Wikipedia</a>
-        <div>
-          <img src="/images/SM64.png">
-        <p>Super Mario 64[a] is a 1996 platform game for the Nintendo 64 and the first Super Mario game to feature 3D gameplay. It was developed by Nintendo EAD and published by Nintendo. As Mario, the player collects power stars while exploring Princess Peach's castle and must rescue her from Bowser. Super Mario 64 features open-world playability, degrees of freedom through all three axes in space, and relatively large areas which are composed primarily of true 3D polygons as opposed to onlytwo-dimensional (2D) sprites. It emphasizes exploration within vast worlds, which require the player to complete various missions in addition to the occasional linear obstacle courses (as in traditional platform games). It preserves many gameplay elements and characters of earlier Mario games as well as the visual style.</p>
+<article>
+  <h1>Nintendo 64 Series</h1>
+  <h2>Super Mario 64</h2>
 
-        <p>Director Shigeru Miyamoto conceived a 3D Mario game during the production of Star Fox (1993). Super Mario 64's development lasted approximately three years; one was spent on designing, the next two on direct work. The visuals were created using the Nichimen N-World toolkit, with Miyamoto aiming to include more details than earlier games. The score was composed by Koji Kondo. A multiplayer mode featuring Mario's brother Luigi was cut, and rumors spread of his inclusion as a hidden character. Along with Pilotwings 64, Super Mario 64 was one of the launch games for the Nintendo 64. Nintendo released it in Japan on June 23, 1996, and later in North America, Europe, and Australia.<p>
+  <p>This article is about the original version. For the remake, see Super Mario 64 DS.</p>
+  <p><a href="https://en.wikipedia.org/wiki/Super_Mario_64">Super Mario 64 From Wikipedia</a></p>
+  <img src="/images/SM64.png">
 
-        <p>Super Mario 64 received critical acclaim and is regarded as one of the greatest video games of all time. Reviewers praised its ambition, visuals, gameplay, and music, although they criticized its unreliable camera system. It is the bestselling Nintendo 64 game, with more than eleven million copies sold by 2003. Featuring a dynamic camera system and 360-degree analog control, it established a new archetype for the 3D genre, much as Super Mario Bros. did for side-scrolling platform games. Numerous developers have cited Super Mario 64 as an influence. It was remade as Super Mario 64 DS for the Nintendo DS in 2004, and it has been ported to other Nintendo consoles.</p>
-        </li>
-        </ol>
-      </fieldset>
-      <fieldset>
-        <ol>
-          <li>
-            <fieldset>
-            <div>
-          <h1>Nintendo GameCube Series</h1>
-          </fieldset>
-          <fieldset>
-          <h2>Super Mario Sunshine</h2>
-        <div>
-          <a href="https://en.wikipedia.org/wiki/Super_Mario_Sunshine">Super Mario Sunshine From Wikipedia, the free encyclopedia</a>
-        </div>
-          <img src="/images/SMS.png">
+  <p>Super Mario 64[a] is a 1996 platform game for the Nintendo 64 and the first Super Mario game to feature 3D gameplay. It was developed by Nintendo EAD and published by Nintendo. As Mario, the player collects power stars while exploring Princess Peach's castle and must rescue her from Bowser. Super Mario 64 features open-world playability, degrees of freedom through all three axes in space, and relatively large areas which are composed primarily of true 3D polygons as opposed to onlytwo-dimensional (2D) sprites. It emphasizes exploration within vast worlds, which require the player to complete various missions in addition to the occasional linear obstacle courses (as in traditional platform games). It preserves many gameplay elements and characters of earlier Mario games as well as the visual style.</p>
 
-          <p>Super Mario Sunshine[a] is a 2002 platform action-adventure game developed and published by Nintendo for the GameCube. It is the second 3D game in the Super Mario series, following Super Mario 64 (1996). The game was directed by Yoshiaki Koizumi and Kenta Usui, produced by series creators Shigeru Miyamoto and Takashi Tezuka, written by Makato Wada, and scored by Koji Kondo and Shinobu Tanaka.</p>
+  <p>Director Shigeru Miyamoto conceived a 3D Mario game during the production of Star Fox (1993). Super Mario 64's development lasted approximately three years; one was spent on designing, the next two on direct work. The visuals were created using the Nichimen N-World toolkit, with Miyamoto aiming to include more details than earlier games. The score was composed by Koji Kondo. A multiplayer mode featuring Mario's brother Luigi was cut, and rumors spread of his inclusion as a hidden character. Along with Pilotwings 64, Super Mario 64 was one of the launch games for the Nintendo 64. Nintendo released it in Japan on June 23, 1996, and later in North America, Europe, and Australia.<p>
 
-          <p>The game takes place on the tropical Isle Delfino, where Mario, Toadsworth, Princess Peach and five Toads are taking a vacation. A villain resembling Mario, known as Shadow Mario, vandalizes the island with graffiti and leaves Mario to be wrongfully convicted for the mess. Mario is ordered to clean up Isle Delfino, using a device called the Flash Liquidizer Ultra Dousing Device (F.L.U.D.D.), while saving Princess Peach from Shadow Mario.<p>
+  <p>Super Mario 64 received critical acclaim and is regarded as one of the greatest video games of all time. Reviewers praised its ambition, visuals, gameplay, and music, although they criticized its unreliable camera system. It is the bestselling Nintendo 64 game, with more than eleven million copies sold by 2003. Featuring a dynamic camera system and 360-degree analog control, it established a new archetype for the 3D genre, much as Super Mario Bros. did for side-scrolling platform games. Numerous developers have cited Super Mario 64 as an influence. It was remade as Super Mario 64 DS for the Nintendo DS in 2004, and it has been ported to other Nintendo consoles.</p>
+</article>
 
-          <p>Super Mario Sunshine received critical acclaim, with reviewers praising the game's graphics, soundtrack, and the addition of F.L.U.D.D. as a mechanic, though some criticized the game's camera and F.L.U.D.D.’s gimmicky nature. The game sold over five million copies worldwide by 2006, making it one of the best-selling GameCube games. The game was re-released as a part of the Player's Choice brand in 2003. Nintendo EPD rereleased it alongside Super Mario 64 and Super Mario Galaxy in the Super Mario 3D All-Stars collection for the Nintendo Switch in 2020.</p>
+<article>
+  <h1>Nintendo GameCube Series</h1>
+  <h2>Super Mario Sunshine</h2>
 
-          </li>
+  <p><a href="https://en.wikipedia.org/wiki/Super_Mario_Sunshine">Super Mario Sunshine From Wikipedia, the free encyclopedia</a></p>
+  <img src="/images/SMS.png">
 
-          </ol>
-          </fieldset>
+  <p>Super Mario Sunshine[a] is a 2002 platform action-adventure game developed and published by Nintendo for the GameCube. It is the second 3D game in the Super Mario series, following Super Mario 64 (1996). The game was directed by Yoshiaki Koizumi and Kenta Usui, produced by series creators Shigeru Miyamoto and Takashi Tezuka, written by Makato Wada, and scored by Koji Kondo and Shinobu Tanaka.</p>
+
+  <p>The game takes place on the tropical Isle Delfino, where Mario, Toadsworth, Princess Peach and five Toads are taking a vacation. A villain resembling Mario, known as Shadow Mario, vandalizes the island with graffiti and leaves Mario to be wrongfully convicted for the mess. Mario is ordered to clean up Isle Delfino, using a device called the Flash Liquidizer Ultra Dousing Device (F.L.U.D.D.), while saving Princess Peach from Shadow Mario.<p>
+
+  <p>Super Mario Sunshine received critical acclaim, with reviewers praising the game's graphics, soundtrack, and the addition of F.L.U.D.D. as a mechanic, though some criticized the game's camera and F.L.U.D.D.’s gimmicky nature. The game sold over five million copies worldwide by 2006, making it one of the best-selling GameCube games. The game was re-released as a part of the Player's Choice brand in 2003. Nintendo EPD rereleased it alongside Super Mario 64 and Super Mario Galaxy in the Super Mario 3D All-Stars collection for the Nintendo Switch in 2020.</p>
+</article>


### PR DESCRIPTION
This template had fieldset elements but was not grouping forms. Elements
should not be used for their default browser appearance effects like
border or spacing, but should be used instead to mark up semantic
structure.

Additionally, div elements that were providing no specific structure
were removed.